### PR TITLE
Further Study for MadLibs Exercise

### DIFF
--- a/flask-madlibs/app.py
+++ b/flask-madlibs/app.py
@@ -29,9 +29,7 @@ def generate_story():
     story_template = STORIES[user_answers.get("id", "")]
     story = Story(
         story_template["prompts"],
-        story_template["story"],
-        story_template["story_name"],
-        story_template["id"],
+        story_template["story"]
     )
 
     user_story = story.generate(user_answers)

--- a/flask-madlibs/app.py
+++ b/flask-madlibs/app.py
@@ -1,5 +1,7 @@
 from flask import Flask, render_template, request
-from static.stories import *
+from random import choice
+from scripts.stories import *
+
 
 app = Flask(__name__)
 
@@ -7,13 +9,31 @@ app = Flask(__name__)
 @app.route("/")
 def home():
     """Generate a form based on a madlib story and prompt the user for answers"""
-    return render_template("index.html", prompts=story.prompts)
+    # ? Does Python support destructuring similar to JS? It seems like it
+    # ? would be useful here.
+    random_story = STORIES[choice(list(STORIES.keys()))]
+
+    return render_template(
+        "index.html",
+        prompts=random_story["prompts"],
+        title=random_story["story_name"],
+        id=random_story["id"],
+    )
 
 
 @app.route("/story", methods=["POST"])
 def generate_story():
     """Construct the user story from their submitted answers and render it to the user."""
     user_answers = request.form.to_dict()
+
+    story_template = STORIES[user_answers.get("id", "")]
+    story = Story(
+        story_template["prompts"],
+        story_template["story"],
+        story_template["story_name"],
+        story_template["id"],
+    )
+
     user_story = story.generate(user_answers)
 
-    return render_template("story.html", story=user_story)
+    return render_template("story.html", story=user_story, title=story.title)

--- a/flask-madlibs/scripts/stories.py
+++ b/flask-madlibs/scripts/stories.py
@@ -1,4 +1,8 @@
 """Madlibs Stories."""
+import json
+
+with open("stories.json", "r") as file:
+    STORIES = json.load(file)
 
 
 class Story:
@@ -33,13 +37,3 @@ class Story:
             text = text.replace("{" + key + "}", val)
 
         return text
-
-
-# Here's a story to get you started
-
-
-story = Story(
-    ["place", "noun", "verb", "adjective", "plural_noun"],
-    """Once upon a time in a long-ago {place}, there lived a
-       large {adjective} {noun}. It loved to {verb} {plural_noun}.""",
-)

--- a/flask-madlibs/stories.json
+++ b/flask-madlibs/stories.json
@@ -1,0 +1,82 @@
+{
+  "1": {
+    "id": "1",
+    "story_name": "Sample Story",
+    "story": "Once upon a time in a long-ago {place}, there lived a large {noun} {verb}. It loved to {adjective} {plural noun}.",
+    "prompts": [
+      "place",
+      "noun",
+      "verb",
+      "adjective",
+      "plural_noun"
+    ]
+  },
+  "2": {
+    "id": "2",
+    "story_name": "If I were President",
+    "story": "My name is {name} and I am {number} years old. If i were president, I'd do a whole bunch of {adjective} things. My first executive order would to ban {verb} and then give every citizen {number_2} {plural_noun}.",
+    "prompts": [
+      "name",
+      "number",
+      "adjective",
+      "verb",
+      "number_2",
+      "plural_noun"
+    ]
+  },
+  "3": {
+    "id": "3",
+    "story_name": "At the Arcade!",
+    "story": "When I go to the arcade with my {plural_noun} there are lots of games to play. I spend lots of time there with my friends. IN the game X-Men you can be differnt {plural_noun_2}. The point of the game is to {verb} every robot.",
+    "prompts": [
+      "plural_noun",
+      "plural_noun_2",
+      "verb"
+    ]
+  },
+  "5": {
+    "id": "5",
+    "story_name": "Trip to the Park",
+    "story": "Yesterday, my friend and I went to the park. On our way to the {adjective} park, we saw big {adjective_2} balloons tied to {noun}. Once we got to the {adjective_3} park, the sky turned {adjective_4}. It started to {verb}  and {verb_2}. My friend and I {verb_3} all the way home. Tomorrow we will try to go to the {adjective_5}  park again and hopefully it doesnt {verb_4}!",
+    "prompts": [
+      "adjective",
+      "adjective_2",
+      "noun",
+      "adjective_3",
+      "adjective_4",
+      "verb",
+      "verb_2",
+      "verb_3",
+      "adjective_5",
+      "verb_4"
+    ]
+  },
+  "6": {
+    "id": "6",
+    "story_name": "Weird News",
+    "story": "A {noun} in {place} was arrested this morning after he was caught {verb_ending_in_ing} in front of {noun_2}. {name} had a history of {ver_2}, but no one-not even his {noun_3}-ever imagined he'd {verb_3} with a {noun_3} stuck in his {part_of_body}. After drinking a {type_of_liquid}, cops followed him to a {place_2} where he reportedly {past_tense_verb} in the fry machine. Later, a woman from {foreign_country} was charged with a similar crime. But rather than {verb_5} with a {noun_5}, she {past_tense_verb_2} with a {adjective} dog. Either way, we imagine that after witnessing him {verb_6} with a {noun_6} there are probably a whole lot of {plural_noun} that are going to need some therapy!",
+    "prompts": [
+      "noun",
+      "place",
+      "verb_ending_in_ing",
+      "noun_2",
+      "name",
+      "verb_2",
+      "noun_3",
+      "verb_3",
+      "noun_4",
+      "part_of_body",
+      "type_of_liquid",
+      "place_2",
+      "past_tense_verb",
+      "foreign_country",
+      "verb_5",
+      "noun_5",
+      "past_tense_verb_2",
+      "adjective",
+      "verb_6",
+      "noun_6",
+      "plural_noun"
+    ]
+  }
+}

--- a/flask-madlibs/templates/base.html
+++ b/flask-madlibs/templates/base.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>MadLibs | {% block subtitle %}{% endblock %} </title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/css/bootstrap.min.css" rel="stylesheet"
+    integrity="sha384-+0n0xVW2eSR5OomGNYDnhzAbDsOXxcvSN1TPprVMTNDbiYZCxYbOOl7+AMvyTG2x" crossorigin="anonymous">
+</head>
+
+<body>
+  <div class="border-bottom py-3 mb-2">
+    <div class="container">
+      <header>
+        <a href="/" class="mb-3 mb-md-0 me-md-auto text-decoration-none fs-4 fw-bold">MadLibs</a>
+      </header>
+    </div>
+  </div>
+  <div class="container">
+    <div class="text-center px-4 py-5 my-3">
+      {% block content %}
+      {% endblock %}
+    </div>
+  </div>
+</body>
+
+</html>

--- a/flask-madlibs/templates/index.html
+++ b/flask-madlibs/templates/index.html
@@ -1,25 +1,26 @@
-<!DOCTYPE html>
-<html lang="en">
+{% extends "base.html" %}
 
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>MadLibs</title>
-</head>
+{% block subtitle %}Home{% endblock %}
 
-<body>
-  <h1>MadLibs</h1>
-  <main>
-    <form action="/story" method="post">
-      {% for prompt in prompts%}
-      <label for={{prompt}}>{{prompt}}:</label>
-      <input type="text" id={{prompt}} name={{prompt}}>
-      <br />
-      {% endfor %}
-      <button>Submit</button>
-    </form>
-  </main>
-</body>
-
-</html>
+{% block content %}
+<!-- <div class="row align-items-center"> -->
+<div class="col=md-10 mx-auto text-center text-lg-start mb-5">
+  <h1 class="fw-bold lh-2 text-center">A hilariously unique story everytime 🤣</h1>
+  <p class="lead text-center">Just fill out the form below and hit <b>generate</b> to let the laughs begin! </p>
+</div>
+<div class="col-md-10 mx-auto col-lg-6">
+  <form action="/story" method="post" class="p-4 p-md-4 bg-light rounded shadow-lg">
+    <h2 class="mb-4">{{ title }}</h2>
+    {% for prompt in prompts %}
+    <div class=" form-floating mb-3">
+      <input class="form-control" type="text" id={{prompt}} name={{prompt}} placeholder={{prompt}} required>
+      <label for={{prompt}}>{{prompt.replace("_", " ")}}</label>
+    </div>
+    {% endfor %}
+    <input type="hidden" name="id" value={{id}}>
+    <button class="btn btn-primary">Generate</button>
+    <!--<button id="new-story" class="btn btn-secondary">New Story</button> -->
+  </form>
+</div>
+<!-- </div> -->
+{% endblock %}

--- a/flask-madlibs/templates/story.html
+++ b/flask-madlibs/templates/story.html
@@ -1,17 +1,12 @@
-<!DOCTYPE html>
-<html lang="en">
+{% extends "base.html" %}
 
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Story</title>
-</head>
+{% block subtitle %}Story{% endblock %}
 
-<body>
-  <h1>MadLibs</h1>
-  <h2>Your MadLib Story</h2>
-  <p>{{story}}</p>
-</body>
-
-</html>
+{% block content %}
+<div class="row align-items-center">
+  <h1 class="mb-4"> {{ title }}</h1>
+  <div class="mx-auto p-4 p-md-5 bg-light col-lg-10 rounded shadow-lg">
+    <p class="lead">{{story}}</p>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
Hi John,

I was hoping you could review some of the _further study_ changes made to the exercise for MadLibs that I've bundled in this pull request. Working through the additional changes I found it a bit tricky. I think the mental shift from working on the client-side to the server-side took is a paradigm shift that I haven't fully solidified. 

To be specific, the original exercise generated a single story when the server was initialized, but I wanted to generate a random story server-side for a user.   The only method I could figure out was to create an Id for the story templates which is then hidden in the form. 

``` python
@app.route("/")
def home():
    """Generate a form based on a madlib story and prompt the user for answers"""
    random_story = STORIES[choice(list(STORIES.keys()))]

    return render_template(
        "index.html",
        prompts=random_story["prompts"],
        title=random_story["story_name"],
        id=random_story["id"],
    )
```

After the form is submitted the story route is using the hidden id parameter to then get the story and generate the story

``` python
@app.route("/story", methods=["POST"])
def generate_story():
    """Construct the user story from their submitted answers and render it to the user."""
    user_answers = request.form.to_dict()

    story_template = STORIES[user_answers.get("id", "")]
    story = Story(
        story_template["prompts"],
        story_template["story"],
    )

    user_story = story.generate(user_answers)

    return render_template("story.html", story=user_story, title=story.title)
```

Does this approach make sense? Or is there a much simpler approach that I'm missing? 